### PR TITLE
only deploy on main branch for repo owner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,7 @@ name: Deploy React Application
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 
@@ -39,6 +37,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2
       - name: deploy to gh-pages
+        if: github.ref == 'refs/heads/master' && github.actor == github.repository.owner
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy React Application
+name: Build, Test, and (maybe) Deploy React Application
 
 on:
   # Triggers the workflow on push or pull request events but only for the main branch


### PR DESCRIPTION
This prevents any attempts to deploy the project that would fail anyway, and only allows the repo owner to deploy.

As a side effect, it allows tests to run when the project is not being deployed.