### PR TITLE
recommend newer version of aqtinstall

### DIFF
--- a/src/State.ts
+++ b/src/State.ts
@@ -16,6 +16,7 @@ import {
   seToolInstallName,
   seModuleInstallName,
 } from "./lib/types";
+import Config from "./config.json";
 
 export const enum SelectValue {
   NotLoaded,
@@ -486,7 +487,7 @@ export class State {
         `    - name: Install Qt
       uses: jurplel/install-qt-action@v${installQtActionVersion}
       with:
-        aqtversion: '==2.1.*'
+        aqtversion: '==${Config.RECOMMEND_AQT_VERSION}'
         host: '${this.host.selected.value}'
         target: '${this.target.selected.value}'
         toolsOnly: 'true'` + toolsLine
@@ -507,7 +508,7 @@ export class State {
       `    - name: Install Qt
       uses: jurplel/install-qt-action@v${installQtActionVersion}
       with:
-        aqtversion: '==2.1.*'
+        aqtversion: '==${Config.RECOMMEND_AQT_VERSION}'
         version: '${this.version.selected.value}'
         host: '${this.host.selected.value}'
         target: '${this.target.selected.value}'

--- a/src/config.json
+++ b/src/config.json
@@ -1,3 +1,4 @@
 {
-  "QT_JSON_CACHE_BASE_URL": "https://ddalcino.github.io/qt-repo-cache/public"
+  "QT_JSON_CACHE_BASE_URL": "https://ddalcino.github.io/qt-repo-cache/public",
+  "RECOMMEND_AQT_VERSION": "3.1.*"
 }


### PR DESCRIPTION
The previous recommendation, `2.1.*`, is very out-of-date, has many bugs, and does not support newer versions of Qt very well. Versions `3.1.*` fix many of these issues. If any users are blindly copying the output of this tool, it is in their best interest to give them a newer aqtinstall.