### PR TITLE
Remove py7zr version requirement

### DIFF
--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -225,7 +225,6 @@ describe("toInstallQtAction", () => {
       uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
-        py7zrversion: '>=0.20.2'
         version: '6.2.0'
         host: 'windows'
         target: 'desktop'
@@ -249,7 +248,6 @@ describe("toInstallQtAction", () => {
       uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
-        py7zrversion: '>=0.20.2'
         host: 'windows'
         target: 'desktop'
         toolsOnly: 'true'
@@ -275,7 +273,6 @@ describe("toInstallQtAction", () => {
       uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
-        py7zrversion: '>=0.20.2'
         host: 'windows'
         target: 'desktop'
         toolsOnly: 'true'
@@ -294,7 +291,6 @@ describe("toInstallQtAction", () => {
       uses: jurplel/install-qt-action@v3
       with:
         aqtversion: '==3.1.*'
-        py7zrversion: '>=0.20.2'
         version: '6.2.0'
         host: 'windows'
         target: 'desktop'

--- a/src/config.json
+++ b/src/config.json
@@ -1,6 +1,6 @@
 {
   "QT_JSON_CACHE_BASE_URL": "https://ddalcino.github.io/qt-repo-cache/public",
   "RECOMMEND_AQT_VERSION": "3.1.*",
-  "REQUIRED_PY7ZR": ">=0.20.2",
+  "REQUIRED_PY7ZR": null,
   "POSTSCRIPT": null
 }


### PR DESCRIPTION
The bug in install-qt-action that requires users to set the py7zr version manually (https://github.com/jurplel/install-qt-action/issues/176) has been fixed, so the py7zr recommendation is no longer necessary. This project should create working workflows properly without specifying py7zr.