### PR TITLE
Fix issues with CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,10 +30,12 @@ jobs:
       - name: Install aqtinstall - requirement for functional tests
         run: pip install aqtinstall==3.1.*
       - name: yarn install, build and test
+        env:
+          SKIP_FUNCTIONAL: "${{ github.ref == 'refs/heads/main' && github.actor == github.repository_owner && '--testPathIgnorePatterns=aqt-list-qt-ts/functional.test.ts' || '' }}"
         run: |
           yarn install --immutable --immutable-cache --check-cache
           yarn run build --if-present
-          yarn test --coverage
+          yarn test --coverage ${SKIP_FUNCTIONAL}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,8 @@ name: Build, Test, and (maybe) Deploy React Application
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
* Skip running fragile functional tests when deploying to gh-pages: there's no reason to repeat them, and failures are mostly false positives
* Don't run all the tests twice for every newly opened PR, or every push to PR