### PR TITLE
Revert "Skip functional test when pushing to main"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,12 +32,10 @@ jobs:
       - name: Install aqtinstall - requirement for functional tests
         run: pip install aqtinstall==3.1.*
       - name: yarn install, build and test
-        env:
-          SKIP_FUNCTIONAL: "${{ github.ref == 'refs/heads/main' && github.actor == github.repository_owner && '--testPathIgnorePatterns=aqt-list-qt-ts/functional.test.ts' || '' }}"
         run: |
           yarn install --immutable --immutable-cache --check-cache
           yarn run build --if-present
-          yarn test --coverage ${SKIP_FUNCTIONAL}
+          yarn test --coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         env:


### PR DESCRIPTION
This reverts commit 3af19ce6ab9cb73a5db7671a6583f37fbd778f72.

Skipping the functional tests was a bad idea and doesn't gain much. If the functional tests fail, I can just rerun the workflow to confirm that things are or aren't working.