### PR TITLE
Updates to match current status of Qt Repo, since Qt 6.7.0

### DIFF
--- a/src/Components/PackageDetailPanel.tsx
+++ b/src/Components/PackageDetailPanel.tsx
@@ -1,17 +1,14 @@
 import React from "react";
-import { PackageUpdate } from "../lib/types";
+import { packageNameToModuleName, PackageUpdate } from "../lib/types";
 
 interface Props {
   pkg: PackageUpdate;
 }
 
-const nickname = (fullname: string): string =>
-  fullname.split(".").at(-2) || fullname;
-
 const PackageDetailPanel = ({ pkg }: Props): JSX.Element => (
   <details>
     <summary>
-      <strong>{nickname(pkg.Name)}:</strong> {pkg.DisplayName}
+      <strong>{packageNameToModuleName(pkg.Name)}:</strong> {pkg.DisplayName}
     </summary>
     {pkg.Description ? (
       <div>

--- a/src/State.test.ts
+++ b/src/State.test.ts
@@ -340,9 +340,9 @@ describe("isWindows", () => {
   `(
     "on $host, isWindows() should return $isWindows",
     ({
-       host,
-       isWindows,
-     }: {
+      host,
+      isWindows,
+    }: {
       host: "windows" | "mac" | "linux";
       isWindows: boolean;
     }) => {
@@ -351,7 +351,6 @@ describe("isWindows", () => {
       expect(state.isWindows()).toEqual(isWindows);
     }
   );
-
 });
 
 describe("toOfficialInstallCmd", () => {

--- a/src/aqt-list-qt-ts/list-qt-impl.test.ts
+++ b/src/aqt-list-qt-ts/list-qt-impl.test.ts
@@ -194,14 +194,16 @@ describe("constructs url for Updates.json", () => {
     version      | arch                   | expected_folder
     ${"5.9.0"}   | ${"wasm_32"}           | ${"qt5_59_wasm"}
     ${"6.2.0"}   | ${"wasm_64"}           | ${"qt6_620_wasm"}
-    ${"6.29.0"}  | ${"wasm_128"}          | ${"qt6_6290_wasm"}
+    ${"6.6.0"}   | ${"wasm_128"}          | ${"qt6_660_wasm"}
     ${"5.12.11"} | ${"wasm_16"}           | ${"qt5_51211_wasm"}
     ${"5.9.0"}   | ${"mingw"}             | ${"qt5_59"}
     ${"6.2.0"}   | ${"mingw"}             | ${"qt6_620"}
-    ${"6.29.0"}  | ${"mingw"}             | ${"qt6_6290"}
+    ${"6.7.0"}   | ${"mingw"}             | ${"qt6_670"}
+    ${"6.8.0"}   | ${"mingw"}             | ${"qt6_680/qt6_680"}
     ${"5.12.11"} | ${"mingw"}             | ${"qt5_51211"}
-    ${"6.29.0"}  | ${"wasm_singlethread"} | ${"qt6_6290_wasm_singlethread"}
-    ${"6.29.0"}  | ${"wasm_multithread"}  | ${"qt6_6290_wasm_multithread"}
+    ${"6.7.0"}   | ${"wasm_singlethread"} | ${"qt6_670_wasm_singlethread"}
+    ${"6.7.0"}   | ${"wasm_multithread"}  | ${"qt6_670_wasm_multithread"}
+    ${"6.8.0"}   | ${"wasm_multithread"}  | ${"qt6_680/qt6_680_wasm_multithread"}
   `(
     `should return url when version is $version, arch is $arch`,
     ({

--- a/src/aqt-list-qt-ts/list-qt-impl.ts
+++ b/src/aqt-list-qt-ts/list-qt-impl.ts
@@ -13,6 +13,7 @@ import semver, { SemVer } from "semver";
 import Config from "../config.json";
 
 const BASE_URL = Config.QT_JSON_CACHE_BASE_URL;
+const HARDCODED_ALLOWED_TOOLS = ["sdktool"];
 
 export const to_versions = (directory: Directory): string[][] => {
   const should_include_folder = (name: string): boolean =>
@@ -143,11 +144,13 @@ export const to_archives = (
   return flattenMaps(maps);
 };
 
-export const to_tools = (directory: Directory): string[] => {
-  return directory.tools
-    .filter((href: string) => href.startsWith("tools_"))
+export const to_tools = (directory: Directory): string[] =>
+  directory.tools
+    .filter(
+      (href: string) =>
+        href.startsWith("tools_") || HARDCODED_ALLOWED_TOOLS.includes(href)
+    )
     .map((href: string) => (href.endsWith("/") ? href.slice(0, -1) : href));
-};
 
 export const to_tool_variants = (
   updates: RawPackageUpdates

--- a/src/aqt-list-qt-ts/list-qt-impl.ts
+++ b/src/aqt-list-qt-ts/list-qt-impl.ts
@@ -169,6 +169,9 @@ const updates_url = (
 ): string => {
   const ver_nodot = `qt${version.major}_${version_nodot(version)}`;
   const _ext = ext ? `_${ext}` : "";
+  if (should_override_host_all_os(target, version)) {
+    host = Host.all_os;
+  }
   const folder =
     version.compare(new SemVer("6.8.0")) >= 0 ? `${ver_nodot}/` : "";
   return `${to_url([host, target])}/${folder}${ver_nodot}${_ext}.json`;
@@ -195,6 +198,9 @@ const choose_ext_for_arch = (args: [Host, Target, SemVer], arch: string) => {
   }
 };
 
+const should_override_host_all_os = (target: Target, version: SemVer) =>
+  target == Target.android && version.compare(new SemVer("6.7.0")) >= 0;
+
 export const to_updates_urls_by_arch =
   (arch: string) =>
   (args: [Host, Target, SemVer]): string =>
@@ -206,6 +212,9 @@ export const to_updates_urls = (
   version: SemVer
 ): string[] => {
   const args: [Host, Target, SemVer] = [host, target, version];
+  if (should_override_host_all_os(target, version)) {
+    args[0] = Host.all_os;
+  }
   const extensions: string[] = ((): string[] => {
     if (target === Target.android && version.major >= 6) {
       return ["arm64_v8a", "armv7", "x86", "x86_64"];

--- a/src/aqt-list-qt-ts/list-qt-impl.ts
+++ b/src/aqt-list-qt-ts/list-qt-impl.ts
@@ -169,7 +169,9 @@ const updates_url = (
 ): string => {
   const ver_nodot = `qt${version.major}_${version_nodot(version)}`;
   const _ext = ext ? `_${ext}` : "";
-  return `${to_url([host, target])}/${ver_nodot}${_ext}.json`;
+  const folder =
+    version.compare(new SemVer("6.8.0")) >= 0 ? `${ver_nodot}/` : "";
+  return `${to_url([host, target])}/${folder}${ver_nodot}${_ext}.json`;
 };
 
 const choose_ext_for_arch = (args: [Host, Target, SemVer], arch: string) => {

--- a/src/aqt-list-qt-ts/list-qt.ts
+++ b/src/aqt-list-qt-ts/list-qt.ts
@@ -9,18 +9,18 @@ import {
 } from "../lib/types";
 import { SemVer } from "semver";
 import {
+  official_releases_url,
   to_arches,
   to_archives,
   to_directory,
   to_modules,
-  to_updates_urls_by_arch,
   to_tool_variants,
   to_tools,
   to_tools_updates_json,
-  to_versions,
-  to_updates_urls,
-  official_releases_url,
   to_unified_installers,
+  to_updates_urls,
+  to_updates_urls_by_arch,
+  to_versions,
 } from "./list-qt-impl";
 import Result from "../lib/Result";
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,12 +22,15 @@ export interface SelectableElement {
 export const seToolInstallName = (se: SelectableElement): string | null =>
   se.pkg === null ? null : se.pkg.Name;
 
+const installableModuleRegex = /^qt\.qt\d\.\d+(\.addons)?\.(.+)\.[^.]+$/;
+export const packageNameToModuleName = (name: string): string =>
+  name.replace(installableModuleRegex, "$2");
+
 export const seModuleInstallName = (se: SelectableElement): string | null => {
   if (se.pkg === null) {
     return null;
   }
-  const parts = se.pkg.Name.split(".");
-  return parts[parts.length - 2];
+  return packageNameToModuleName(se.pkg.Name);
 };
 
 export interface RawPackageUpdate {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -103,8 +103,11 @@ export type Directory = { qt: string[]; tools: string[] };
 
 export enum Host {
   windows,
+  windows_arm64,
   mac,
   linux,
+  linux_arm64,
+  all_os,
 }
 export type HostString = keyof typeof Host;
 export const hostToStr = (h: Host): string => Host[h];

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,14 +1,26 @@
 import { Host, Target } from "./types";
 
-export const hosts: Readonly<Host[]> = [Host.windows, Host.mac, Host.linux];
+export const hosts: Readonly<Host[]> = [
+  Host.windows,
+  Host.windows_arm64,
+  Host.mac,
+  Host.linux,
+  Host.linux_arm64,
+];
 export const targetsForHost = (host: Host): Target[] => {
   switch (host) {
     case Host.linux:
       return [Target.desktop, Target.android];
+    case Host.linux_arm64:
+      return [Target.desktop];
     case Host.mac:
       return [Target.desktop, Target.android, Target.ios];
     case Host.windows:
       return [Target.desktop, Target.android, Target.winrt];
+    case Host.windows_arm64:
+      return [Target.desktop];
+    case Host.all_os:
+      return [];
   }
 };
 


### PR DESCRIPTION
* Fix display of Qt 6.8.0 (fix #44)
* Add arm64 targets for Win & Linux
* Fetch android versions from all_os directory above Qt 6.7.0
* Add sdktool to output (fix #26)
* Fix display of module names ending in `.debug_information`, new since Qt 6.7.0