### PR TITLE
Record coverage properly

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           npm ci
           npm run build --if-present
-          npm test --coverage
+          npm test -- --coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
         env:


### PR DESCRIPTION
The Yarn way was:
```
yarn test --coverage
```
The npm call is different:
```
npm test -- --coverage
```