### PR TITLE
Support dark mode with help from CSS System Colors

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -1,4 +1,8 @@
 
+:root {
+  color-scheme: light dark;
+}
+
 .horizontal-flow {
   display: flex;
   flex-direction: row;
@@ -26,7 +30,7 @@ pre {
   padding: 1em;
   overflow-x: auto;
   border-left: 0.2em solid blue;
-  background-color: lightgrey;
+  background-color: color-mix(in srgb, CanvasText 12%, Canvas) /* mimic "lightgrey" */;
 }
 pre code {
   white-space: pre-wrap;


### PR DESCRIPTION
Hello!

<img height="300" alt="Screenshot of both light and dark webpage" src="https://github.com/user-attachments/assets/1bccc7bd-fa0e-4cea-a5a3-925683ea98ec" />

.

- \<system-color\> CSS type - CSS | MDN - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/system-color
- color-scheme CSS property - CSS | MDN - https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/color-scheme

.